### PR TITLE
révision de l'étape 'génération du QR' dans l'exemple de validation

### DIFF
--- a/input/data/expansion-params.json
+++ b/input/data/expansion-params.json
@@ -4,7 +4,7 @@
     "parameter": [
         {
             "name": "system-version",
-            "valueUri": "http://snomed.info/sct|http://snomed.info/sct/11000315107/version/20240621"
+            "valueUri": "http://snomed.info/sct|http://snomed.info/sct/11000315107"
         }
     ]
 }

--- a/input/fsh/applications/dpi/codesystems/CodeSystem-DpiGender.fsh
+++ b/input/fsh/applications/dpi/codesystems/CodeSystem-DpiGender.fsh
@@ -6,6 +6,7 @@ Description: "TODO"
 * ^content = #complete
 * ^hierarchyMeaning = #grouped-by
 * ^caseSensitive = false
+* ^experimental = false
 
 * #h "Homme"
 * #f "Femme"

--- a/input/fsh/applications/dpi/valuesets/ValueSet-DpiGender.fsh
+++ b/input/fsh/applications/dpi/valuesets/ValueSet-DpiGender.fsh
@@ -1,7 +1,8 @@
 ValueSet: DpiGender
 Title: "ValueSet of gender from DPI"
+Description: "ToDo"
 
 * ^experimental = false
 * ^immutable = false
 
-* include codes from system DpiGender
+* include codes from system https://aphp.fr/ig/fhir/dm/CodeSystem/DpiGender

--- a/input/pagecontent/use-core-validation.md
+++ b/input/pagecontent/use-core-validation.md
@@ -4,14 +4,12 @@
 <ol>
   <li>
     <p><b>Un exemple de réponse issue du <a href="Questionnaire-UsageCore.html">questionnaire des variables socles</a></b> :</p>
-    <p>On utilise Postman pour charger <a href="CodeSystem-DpiGender.html">le CodeSystem utile à l'alimentation du champ `Sexe`</a> et <a href="ValueSet-DpiGender.html">le ValueSet correspondant</a> dans un serveur FHIR (par exemple <a href="https://hapi.fhir.org/baseR4">le serveur HAPI R4 publique</a>).
-    On peut alors utiliser le <a href="https://fhirpath-lab.azurewebsites.net/Questionnaire/tester/">Form Tester</a>, un outil open source qui propose une interface de saisie et qui génère la ressource QuestionnaireResponse correspondant aux données saisies dans l'interface. Pour cela, il faut : 
-      <ul>
-        <li>Dans l'onglet DETAIL, coller la ressource <a href="Questionnaire-UsageCore.html">questionnaire des variables socles</a> dans le champ du milieu</li>
-        <li>Dans l'onglet CONTEXT, paramétrer l'url du serveur FHIR utiliser dans le champ `Data Server`</li>
-        <li>Dans l'onglet LHC-FORMS, renseigner le Questionnaire comme on le souhaite, puis cliquer sur SHOW RESPONSE</li> 
-        <li>Copier la ressource présente dans le champ de droite et la coller dans le dossier `input/test-map/usages/core/QuestionnaireResponse-UsageCoreTest.json`.</li> 
-      </ul>
+    <p>On peut  utiliser le <a href="https://lhcforms.nlm.nih.gov/lhcforms">LHC-Forms Widget</a>, un outil open source qui propose une interface de saisie et qui génère la ressource QuestionnaireResponse correspondant aux données saisies dans l'interface : 
+      <ol>
+        <li>On charge <a href="Questionnaire-UsageCore.html">le JSON du Questionnaire</a> via le bouton vert "Load From File",</li>
+        <li>On saisi les données que l'on souhaite dans l'interface,</li>
+        <li>On enregistre la ressource QuestionnaireResponse via le bouton bleu "Show Form Data As ..." en choisissant l'option "FHIR SDC QuestionnaireResponse"</li>
+      </ol>
     </p>
     <p><b>Le résultat</b> : <a href="QuestionnaireResponse-qr-test-usage-core.html">un exemple de réponse</a></p>
   </li>

--- a/input/resources/usages/core/Questionnaire-UsageCore.json
+++ b/input/resources/usages/core/Questionnaire-UsageCore.json
@@ -245,18 +245,16 @@
               ]
             },
             {
-              "linkId": "7621032273792",
-              "text": "IRIS",
-              "type": "choice",
-              "repeats": true,
-              "answerValueSet": "https://insee.fr/IRIS-vs",
               "item": [
                 {
+                  "type": "date",
                   "linkId": "4999580038872",
-                  "text": "Date du recueil de l'information",
-                  "type": "date"
+                  "text": "Date du recueil de l'information"
                 },
                 {
+                  "linkId": "7621032273792_intention",
+                  "type": "display",
+                  "text": "Codage de l'adresse du patient selon la méthode d'Ilots Regroupés pour l'Information Statistique de l'INSEE. Si adresse géocodée non disponible",
                   "extension": [
                     {
                       "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -271,10 +269,41 @@
                         "text": "Intention"
                       }
                     }
-                  ],
-                  "linkId": "7621032273792_intention",
-                  "text": "Codage de l'adresse du patient selon la méthode d'Ilots Regroupés pour l'Information Statistique de l'INSEE. Si adresse géocodée non disponible",
-                  "type": "display"
+                  ]
+                }
+              ],
+              "type": "choice",
+              "linkId": "7621032273792",
+              "text": "IRIS",
+              "repeats": true,
+              "answerOption": [
+                {
+                  "valueCoding": {
+                    "system": "https://inse.fr/IRIS-cs",
+                    "code": "010010000",
+                    "display": "L'Abergement-Clémenciat (commune non irisée)"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "system": "https://inse.fr/IRIS-cs",
+                    "code": "010040102",
+                    "display": "Longeray-Gare"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "system": "https://inse.fr/IRIS-cs",
+                    "code": "765400102",
+                    "display": "Vieux Marché Palais de Justice"
+                  }
+                },
+                {
+                  "valueCoding": {
+                    "system": "https://inse.fr/IRIS-cs",
+                    "code": "391900000",
+                    "display": "Dampierre (commune non irisée)"
+                  }
                 }
               ]
             },
@@ -345,23 +374,37 @@
           ]
         },
         {
+          "type": "choice",
           "linkId": "3894630481120",
           "text": "Sexe",
-          "type": "choice",
-          "answerValueSet": "https://aphp.fr/ig/fhir/dm/ValueSet/DpiGender"
-        },
-        {
-          "linkId": "2446369196222",
-          "text": "Code géographique de résidence",
-          "type": "choice",
-          "answerValueSet": "https://atih.sante.fr/CodesGeographiques-vs",
-          "item": [
+          "answerOption": [
             {
-              "linkId": "1537511139540",
-              "text": "Date du recueil de l'information",
-              "type": "date"
+              "valueCoding": {
+                "system": "https://aphp.fr/ig/fhir/dm/CodeSystem/DpiGender",
+                "code": "h",
+                "display": "Homme"
+              }
             },
             {
+              "valueCoding": {
+                "system": "https://aphp.fr/ig/fhir/dm/CodeSystem/DpiGender",
+                "code": "f",
+                "display": "Femme"
+              }
+            }
+          ]
+        },
+        {
+          "item": [
+            {
+              "type": "date",
+              "linkId": "1537511139540",
+              "text": "Date du recueil de l'information"
+            },
+            {
+              "linkId": "2446369196222_intention",
+              "type": "display",
+              "text": "Code de la commune de résidence du patient selon la classification PMSI",
               "extension": [
                 {
                   "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
@@ -376,10 +419,40 @@
                     "text": "Intention"
                   }
                 }
-              ],
-              "linkId": "2446369196222_intention",
-              "text": "Code de la commune de résidence du patient selon la classification PMSI",
-              "type": "display"
+              ]
+            }
+          ],
+          "type": "choice",
+          "linkId": "2446369196222",
+          "text": "Code géographique de résidence",
+          "answerOption": [
+            {
+              "valueCoding": {
+                "system": "https://ati.sante.fr/CodesGeographiques-cs",
+                "code": "04C01",
+                "display": "LA CONDAMINE CHATELARD"
+              }
+            },
+            {
+              "valueCoding": {
+                "system": "https://ati.sante.fr/CodesGeographiques-cs",
+                "code": "01290",
+                "display": "PONT DE VEYLE"
+              }
+            },
+            {
+              "valueCoding": {
+                "system": "https://ati.sante.fr/CodesGeographiques-cs",
+                "code": "76000",
+                "display": "ROUEN"
+              }
+            },
+            {
+              "valueCoding": {
+                "system": "https://ati.sante.fr/CodesGeographiques-cs",
+                "code": "70180",
+                "display": "DAMPIERRE SUR SALON"
+              }
             }
           ]
         },
@@ -1935,14 +2008,26 @@
               "text": "codification",
               "type": "choice",
               "repeats": true,
-              "answerValueSet": "https://medicament/ATC-UCD-CIP-DCI-libellé_commercial"
+              "answerValueSet": "https://smt.esante.gouv.fr/terminologie-atc?vs",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-preferredTerminologyServer",
+                  "valueUrl": "https://smt.esante.gouv.fr/fhir"
+                }
+              ]
             },
             {
               "linkId": "387026794874",
               "text": "Voie d'administration",
               "type": "choice",
               "repeats": false,
-              "answerValueSet": "https://standardterms.edqm.eu/"
+              "answerValueSet": "https://smt.esante.gouv.fr/terminologie-standardterms?vs",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-preferredTerminologyServer",
+                  "valueUrl": "https://smt.esante.gouv.fr/fhir"
+                }
+              ]
             },
             {
               "extension": [
@@ -2017,14 +2102,26 @@
               "text": "codification",
               "type": "choice",
               "repeats": true,
-              "answerValueSet": "https://medicament/ATC-UCD-CIP-DCI-libellé_commercial"
+              "answerValueSet": "https://smt.esante.gouv.fr/terminologie-atc?vs",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-preferredTerminologyServer",
+                  "valueUrl": "https://smt.esante.gouv.fr/fhir"
+                }
+              ]
             },
             {
               "linkId": "811931484859",
               "text": "Voie d'administration",
               "type": "choice",
               "repeats": false,
-              "answerValueSet": "https://standardterms.edqm.eu/"
+              "answerValueSet": "https://smt.esante.gouv.fr/terminologie-standardterms?vs",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-preferredTerminologyServer",
+                  "valueUrl": "https://smt.esante.gouv.fr/fhir"
+                }
+              ]
             },
             {
               "extension": [
@@ -2401,13 +2498,20 @@
   "resourceType": "Questionnaire",
   "id": "UsageCore",
   "meta": {
-    "versionId": "15",
-    "lastUpdated": "2025-04-25T09:57:49.017+00:00",
+    "versionId": "2",
+    "lastUpdated": "2025-05-14T15:14:59.520+00:00",
     "source": "https://aphp.fr/ig/fhir/eds/Endpoint/form-builder"
   },
+  "url": "https://aphp.fr/ig/fhir/dm/Questionnaire/UsageCore",
   "name": "UsageCore",
   "title": "Questionnaire usage Variables socles pour les EDSH",
   "status": "active",
   "date": "2025-02-03",
-  "description": "Arborescence des variables du socle pour les EDSH"
+  "description": "Arborescence des variables du socle pour les EDSH",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-preferredTerminologyServer",
+      "valueUrl": "https://hapi.fhir.org/baseR4"
+    }
+  ]
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,6 +16,7 @@ publisher:
   # email: test@example.org
 
 dependencies:
+  hl7.fhir.uv.sdc: 3.0.0
   hl7.fhir.fr.core: 2.1.0
   ans.fhir.fr.annuaire: 1.1.0
 


### PR DESCRIPTION
Il y a  : 
- des modifications du Questionnaire pour limiter les ressource à créer
- un bundle qui contient les ressources que j'ai pas pu virer (ça doit pouvoir se discuter)
- correction de quelques coquilles. 

Attention, le chargement dans le Hapi de demo mondial est un peu capricieux, ce d'autant que j'ai créé les ressources donc les utilisateurs qui feraient le test auront une erreur (la ressource existe déjà) : il a mis un peu de temps à faire les expand et il y en a un qu'il avait toujours pas fait quand j'ai arrété d'essayé. 